### PR TITLE
Added Kotlin Coroutines Library (See #3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext."signing.password" = signPassword
     ext."signing.secretKeyRingFile" = signFile
 
-    ext.kotlin_version = '1.2.21'
+    ext.kotlin_version = '1.3.0-rc-190'
 
     repositories {
         maven { url "http://files.minecraftforge.net/maven" }
@@ -15,7 +15,7 @@ buildscript {
 }
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.2.21'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.0-rc-190'
     id 'org.jetbrains.dokka' version '0.9.16'
     id 'com.matthewprenger.cursegradle' version '1.0.10'
     id 'com.jfrog.bintray' version '1.8.0'
@@ -41,6 +41,7 @@ minecraft {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0-RC1'
 }
 
 processResources {
@@ -61,6 +62,7 @@ processResources {
 repositories {
     jcenter()
     mavenCentral()
+    maven { url "https://kotlin.bintray.com/kotlin-eap" }
 }
 
 compileKotlin.kotlinOptions.jvmTarget = "1.8"


### PR DESCRIPTION
Updated Kotlin version to the 1.3 EAP version because Coroutines are
still an experimental feature.

I noticed some caveats during testing if everything's still working correctly:

1. As I wrote above, one needs to use an EAP version of Kotlin.
2. At least with IntelliJ Idea this makes it a bit of a hassle to work with the ide because it compiles all files with it's own Kotlin Plugin's compiler, so you need to enable the EAP version of the plugin first. After changing the Kotlin version Idea uses to compile I needed to invalidate caches and restart (Option in File Menu) for this change to be persistent. -> The main problem is that IntelliJ does **not** respect the kotlin version set in ```build.gradle```.

But everything is working correctly. I tested by adding a coroutine to the preInit method, which worked as it should, without any additional problems. Note: I only ran it in the development environment and did not check if it's working with other mods or outside the dev environment.